### PR TITLE
Withdrawal Fee Wallet Smart Contract in Clarity.

### DIFF
--- a/lamp_contrants/Clarinet.toml
+++ b/lamp_contrants/Clarinet.toml
@@ -19,6 +19,11 @@ epoch = 2.5
 path = 'contracts/reward_distribytion.clar'
 clarity_version = 2
 epoch = 2.5
+
+[contracts.withdrawal_fee_wallet]
+path = 'contracts/withdrawal_fee_wallet.clar'
+clarity_version = 2
+epoch = 2.5
 [repl.analysis]
 passes = ['check_checker']
 

--- a/lamp_contrants/contracts/withdrawal_fee_wallet.clar
+++ b/lamp_contrants/contracts/withdrawal_fee_wallet.clar
@@ -1,0 +1,116 @@
+;; Withdrawal Fee Wallet Smart Contract
+;; This contract allows users to deposit STX and withdraw with a small fee
+
+;; Constants
+(define-constant CONTRACT_OWNER tx-sender)
+(define-constant ERR_OWNER_ONLY (err u100))
+(define-constant ERR_INSUFFICIENT_BALANCE (err u101))
+(define-constant ERR_INVALID_AMOUNT (err u102))
+(define-constant ERR_TRANSFER_FAILED (err u103))
+
+;; Data Variables
+(define-data-var withdrawal-fee-percentage uint u250) ;; 2.5% (250 basis points)
+
+;; Data Maps
+(define-map user-balances principal uint)
+
+;; Read-only functions
+
+;; Get user balance
+(define-read-only (get-balance (user principal))
+  (default-to u0 (map-get? user-balances user))
+)
+
+;; Get withdrawal fee percentage (in basis points, 10000 = 100%)
+(define-read-only (get-withdrawal-fee-percentage)
+  (var-get withdrawal-fee-percentage)
+)
+
+;; Calculate withdrawal fee for a given amount
+(define-read-only (calculate-withdrawal-fee (amount uint))
+  (/ (* amount (var-get withdrawal-fee-percentage)) u10000)
+)
+
+;; Calculate net withdrawal amount (amount minus fee)
+(define-read-only (calculate-net-withdrawal (amount uint))
+  (let ((fee (calculate-withdrawal-fee amount)))
+    (- amount fee)
+  )
+)
+
+;; Get contract owner
+(define-read-only (get-contract-owner)
+  CONTRACT_OWNER
+)
+
+;; Public functions
+
+;; Deposit STX to the wallet
+(define-public (deposit (amount uint))
+  (let ((current-balance (get-balance tx-sender)))
+    (begin
+      ;; Transfer STX from user to contract
+      (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+      ;; Update user balance
+      (map-set user-balances tx-sender (+ current-balance amount))
+      (ok amount)
+    )
+  )
+)
+
+;; Withdraw STX with fee deduction
+(define-public (withdraw (amount uint))
+  (let (
+    (user-balance (get-balance tx-sender))
+    (withdrawal-fee (calculate-withdrawal-fee amount))
+    (net-amount (- amount withdrawal-fee))
+  )
+    (begin
+      ;; Check if user has sufficient balance
+      (asserts! (>= user-balance amount) ERR_INSUFFICIENT_BALANCE)
+      ;; Check if amount is valid (greater than 0)
+      (asserts! (> amount u0) ERR_INVALID_AMOUNT)
+      
+      ;; Update user balance (deduct full amount)
+      (map-set user-balances tx-sender (- user-balance amount))
+      
+      ;; Transfer net amount to user
+      (try! (as-contract (stx-transfer? net-amount tx-sender tx-sender)))
+      
+      ;; Transfer fee to contract owner
+      (try! (as-contract (stx-transfer? withdrawal-fee tx-sender CONTRACT_OWNER)))
+      
+      (ok {
+        withdrawn: net-amount,
+        fee: withdrawal-fee,
+        remaining-balance: (- user-balance amount)
+      })
+    )
+  )
+)
+
+;; Owner-only functions
+
+;; Set withdrawal fee percentage (only contract owner)
+(define-public (set-withdrawal-fee-percentage (new-fee-percentage uint))
+  (begin
+    ;; Check if caller is contract owner
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_OWNER_ONLY)
+    ;; Fee percentage should not exceed 100% (10000 basis points)
+    (asserts! (<= new-fee-percentage u10000) ERR_INVALID_AMOUNT)
+    ;; Update fee percentage
+    (var-set withdrawal-fee-percentage new-fee-percentage)
+    (ok new-fee-percentage)
+  )
+)
+
+;; Emergency withdraw function for contract owner
+(define-public (emergency-withdraw (amount uint))
+  (begin
+    ;; Check if caller is contract owner
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_OWNER_ONLY)
+    ;; Transfer STX from contract to owner
+    (try! (as-contract (stx-transfer? amount tx-sender CONTRACT_OWNER)))
+    (ok amount)
+  )
+)

--- a/lamp_contrants/tests/withdrawal_fee_wallet.test.ts
+++ b/lamp_contrants/tests/withdrawal_fee_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><body>
<hr>
<h1>💸 Withdrawal Fee Wallet Smart Contract</h1>
<p>This Clarity smart contract implements a simple custodial wallet where users can <strong>deposit STX</strong> and <strong>withdraw funds with a small fee</strong>. The withdrawal fee is configurable by the contract owner and collected in <strong>basis points (bps)</strong>, where <code inline="">10000 = 100%</code>.</p>
<hr>
<h2>⚙️ Features</h2>
<ul>
<li>
<p>✅ Deposit STX into the contract securely.</p>
</li>
<li>
<p>✅ Withdraw STX with an applied <strong>fee deduction</strong>.</p>
</li>
<li>
<p>✅ Owner-configurable withdrawal fee percentage (in basis points).</p>
</li>
<li>
<p>✅ Read-only helper functions for balances, fees, and net withdrawal calculation.</p>
</li>
<li>
<p>✅ Emergency withdrawal function for the contract owner.</p>
</li>
</ul>
<hr>
<h2>📑 Contract Details</h2>
<h3>Constants</h3>
<ul>
<li>
<p><code inline="">CONTRACT_OWNER</code> → The wallet that deploys the contract.</p>
</li>
<li>
<p><code inline="">ERR_OWNER_ONLY (u100)</code> → Error when non-owners attempt restricted actions.</p>
</li>
<li>
<p><code inline="">ERR_INSUFFICIENT_BALANCE (u101)</code> → Error when balance is too low.</p>
</li>
<li>
<p><code inline="">ERR_INVALID_AMOUNT (u102)</code> → Error for invalid amounts (e.g., <code inline="">0</code>).</p>
</li>
<li>
<p><code inline="">ERR_TRANSFER_FAILED (u103)</code> → Error if a transfer fails.</p>
</li>
</ul>
<h3>Data Variables</h3>
<ul>
<li>
<p><code inline="">withdrawal-fee-percentage</code> → Defaults to <strong>250 bps (2.5%)</strong>.</p>
</li>
</ul>
<h3>Data Maps</h3>
<ul>
<li>
<p><code inline="">user-balances</code> → Tracks each user’s deposited STX balance.</p>
</li>
</ul>
<hr>
<h2>🔍 Read-Only Functions</h2>

Function | Description
-- | --
get-balance (user) | Returns a user’s balance (default u0).
get-withdrawal-fee-percentage | Returns the current fee in basis points.
calculate-withdrawal-fee (amount) | Computes fee for a given withdrawal.
calculate-net-withdrawal (amount) | Computes net amount after fee deduction.
get-contract-owner | Returns the contract owner address.


<hr>
<h2>🏦 Fee Example</h2>
<ul>
<li>
<p>Withdrawal fee percentage: <strong>2.5% (250 bps)</strong></p>
</li>
<li>
<p>User withdraws: <code inline="">1,000 STX</code></p>
</li>
<li>
<p>Fee = <code inline="">1000 * 250 / 10000 = 25 STX</code></p>
</li>
<li>
<p>Net withdrawal = <code inline="">975 STX</code></p>
</li>
<li>
<p>Owner receives <code inline="">25 STX</code></p>
</li>
</ul>
<hr>
<h2>🚀 Deployment &amp; Usage</h2>
<ol>
<li>
<p>Deploy contract to Stacks blockchain (mainnet or testnet).</p>
</li>
<li>
<p>Users can:</p>
<ul>
<li>
<p>Call <code inline="">deposit(amount)</code> with STX to fund their wallet.</p>
</li>
<li>
<p>Call <code inline="">withdraw(amount)</code> to receive STX minus the fee.</p>
</li>
</ul>
</li>
<li>
<p>Owner can:</p>
<ul>
<li>
<p>Adjust the fee via <code inline="">set-withdrawal-fee-percentage</code>.</p>
</li>
<li>
<p>Execute <code inline="">emergency-withdraw</code> if needed.</p>
</li>
</ul>
</li>
</ol>
<hr>
<h2>⚠️ Security Considerations</h2>
<ul>
<li>
<p>Users <strong>must trust the contract owner</strong>, since the owner can change withdrawal fees or drain contract funds via <code inline="">emergency-withdraw</code>.</p>
</li>
<li>
<p>Recommended for <strong>experiments, demos, or controlled environments</strong>, not for production custody without further safeguards.</p>
</li>
</ul>
<hr>
</body></html><!--EndFragment-->
</body>
</html>